### PR TITLE
Wireguard offlinessid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  push:
+    branches: [ "wireguard", "fastd" ]
+  pull_request:
+    branches: [ "wireguard", "fastd" ]
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_gluon:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Running jenkins job 'ffkbu-multihood-stable-${{ github.base_ref }}-gluon2021.X-ci'
+        uses: Mondtic/build-jenkins-job@master
+        with:
+          jenkins-url: https://jenkins.kbu.freifunk.net
+          jenkins-token: ${{ secrets.JENKINS_CI_TOKEN }}
+          jenkins-user: ${{ secrets.JENKINS_CI_USER }}
+          jenkins-job: ffkbu-multihood-stable-${{ github.base_ref }}-gluon2021.X-ci
+          jenkins-wait-job: "wait"
+          jenkins-ssl-verify: "true"
+          jenkins-job-params: '{"SITEBRANCH": "${{ github.head_ref }}"}'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/ff-kbu/site-ffkbu-multidomain/actions/workflows/ci.yml/badge.svg?branch=wireguard)](https://github.com/ff-kbu/site-ffkbu-multidomain/actions/workflows/ci.yml)
+
 Freifunk KBU Multihood with Batman15 and 802.11s
 
 

--- a/modules
+++ b/modules
@@ -3,7 +3,7 @@
 #
 # In most cases, it is not required so don't add it.
 
-GLUON_SITE_FEEDS="wgkbu fileskbu"
+GLUON_SITE_FEEDS="wgkbu fileskbu ssidchanger"
 PACKAGES_WGKBU_REPO=https://github.com/johnnybee/gluon-mesh-vpn-wireguard.git
 PACKAGES_WGKBU_COMMIT=3d6a2dc643b0f5477b5c3ca28990c26b165b5452
 PACKAGES_WGKBU_BRANCH=master
@@ -11,3 +11,7 @@ PACKAGES_WGKBU_BRANCH=master
 PACKAGES_FILESKBU_REPO=https://github.com/johnnybee/gluon-ffkbu-files.git
 PACKAGES_FILESKBU_COMMIT=649b3986aa8268f0c186d7f4e14a9b260c8a93eb
 PACKAGES_FILESKBU_BRANCH=master
+
+PACKAGES_SSIDCHANGER_REPO=https://github.com/ff-kbu/gluon-ssid-changer.git
+PACKAGES_SSIDCHANGER_COMMIT=e33167fba5b92578cb2b5d9ee37c62ed1f736ec8
+PACKAGES_SSIDCHANGER_BRANCH=master

--- a/site.conf
+++ b/site.conf
@@ -108,4 +108,22 @@
       obligatory = true,
     },
   },
+
+  ssid_changer = {
+    enabled = true,
+    switch_timeframe = 1,    -- only once every timeframe (in minutes) the SSID will change to the Offline-SSID
+                              -- set to 1440 to change once a day
+                              -- set to 1 minute to change every time the router gets offline
+    first = 1,                -- the first few minutes directly after reboot within which an Offline-SSID may be
+                              -- activated every minute (must be <= switch_timeframe)
+    prefix = 'FF_Offline_',   -- use something short to leave space for the nodename (no '~' allowed!)
+    suffix = 'nodename',      -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
+
+    tq_limit_enabled = false, -- if false, the offline SSID will only be set if there is no gateway reacheable
+                              -- if true, set upper and lower limit to turn the offline_ssid on and off
+                              -- in-between these two values the SSID will never be changed to prevent it from
+                              -- toggeling every minute:
+    tq_limit_max = 45,        -- upper limit, above that the online SSID will be used
+    tq_limit_min = 35         -- lower limit, below that the offline SSID will be used
+  }
 }

--- a/site.conf
+++ b/site.conf
@@ -2,7 +2,7 @@
   site_code = 'ffkbu',
   default_domain = 'ffkbu_hood_bonn',
 
- -- Timezone of your community.
+  -- Timezone of your community.
   -- See http://wiki.openwrt.org/doc/uci/system#time_zones
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',
 
@@ -29,15 +29,21 @@
     },
   },
 
---  mesh = {
---    vxlan = true,
---    batman_adv = {
---      routing_algo = 'BATMAN_V',
---    },
---  },
+  --  mesh = {
+  --    vxlan = true,
+  --    batman_adv = {
+  --      routing_algo = 'BATMAN_V',
+  --    },
+  --  },
+
+  mesh_vpn = {
+      mtu = 1398,
+      fastd = {
+        methods = {'salsa2012+umac'},
+      },
+    },
 
   autoupdater = {
-    -- Default branch. Don't forget to set GLUON_BRANCH when building!
     branch = 'stable',
 
     -- List of branches. You may define multiple branches.
@@ -47,7 +53,7 @@
 
         -- List of mirrors to fetch images from. IPv6 required!
         mirrors = {
-                'http://updates.ffkbu/autoupdater/multidomain/stable/wireguard/sysupgrade',
+          'http://updates.ffkbu/autoupdater/multidomain/stable/fastd/sysupgrade',
         },
 
         -- Number of good signatures required.
@@ -58,34 +64,31 @@
 
         -- List of public keys of maintainers.
         pubkeys = {
-                'b35dfb30ab9f54064209d9cb6042d6509cdfdd19352798ef6c3fd61787d4008f', -- JohnnyBee
-                '76a44fbb724444ecddc2f683b9e53e061f612a6bfad956b2217c7fc0a82f2df5', -- K3V1N
-                '360793e1469e134e99fdecf543202dd0b5b1779299372ac1a4e7c3cad5aade89', -- Simon
-                '1c38f1cb1d3900ad053519d7e2b689bb8ae2e59ff72a9e571d4bb559dada3e7a', -- g3ntleman
-                '7948cea2d21d94bcf59ef5be2dc248de7d7b828b82993bde1758876560c12c27', -- zygentoma
+          'b35dfb30ab9f54064209d9cb6042d6509cdfdd19352798ef6c3fd61787d4008f', -- JohnnyBee
+          '76a44fbb724444ecddc2f683b9e53e061f612a6bfad956b2217c7fc0a82f2df5', -- K3V1N
+          '360793e1469e134e99fdecf543202dd0b5b1779299372ac1a4e7c3cad5aade89', -- Simon
+          '1c38f1cb1d3900ad053519d7e2b689bb8ae2e59ff72a9e571d4bb559dada3e7a', -- g3ntleman
+          '7948cea2d21d94bcf59ef5be2dc248de7d7b828b82993bde1758876560c12c27', -- zygentoma
         },
       },
     },
   },
 
   mesh_vpn = {
-
-        bandwidth_limit = {
-                -- The bandwidth limit can be enabled by default here.
-                enabled = false,
-                -- Default upload limit (kbit/s).
-                egress = 200,
-                -- Default download limit (kbit/s).
-                ingress = 3000,
-                },
+    bandwidth_limit = {
+      -- The bandwidth limit can be enabled by default here.
+      enabled = false,
+      -- Default upload limit (kbit/s).
+      egress = 200,
+      -- Default download limit (kbit/s).
+      ingress = 3000,
+      },
   },
-
-
-
 
   setup_mode = {
     skip = false,
   },
+
   config_mode = {
     hostname = {
       optional = false,

--- a/site.mk
+++ b/site.mk
@@ -1,157 +1,134 @@
-##      gluon site.mk makefile example
-
-##	GLUON_FEATURES
-#		Specify Gluon features/packages to enable;
-#		Gluon will automatically enable a set of packages
-#		depending on the combination of features listed
-##      GLUON_SITE_PACKAGES
-#               specify gluon/openwrt packages to include here
-#               The gluon-mesh-batman-adv-* package must come first because of the dependency resolution
-
 GLUON_FEATURES := \
-        autoupdater \
-        config-mode-geo-location-osm \
-        ebtables-filter-multicast \
-        ebtables-filter-ra-dhcp \
-        ebtables-limit-arp \
-        mesh-batman-adv-15 \
-        respondd \
-        status-page \
-        web-advanced \
-        web-private-wifi \
-        web-wizard \
-	config-mode-domain-select 
-         
+  autoupdater \
+  config-mode-geo-location-osm \
+  ebtables-filter-multicast \
+  ebtables-filter-ra-dhcp \
+  ebtables-limit-arp \
+  mesh-batman-adv-15 \
+  respondd \
+  status-page \
+  web-advanced \
+  web-private-wifi \
+  web-wizard \
+	config-mode-domain-select
+
 GLUON_SITE_PACKAGES := \
-        haveged \
-        iptables \
-        iwinfo \
-        gluon-ffkbu-files \
-        gluon-mesh-vpn-wireguard
-        
+  haveged \
+  iptables \
+  iwinfo \
+  gluon-ffkbu-files \
+  gluon-mesh-vpn-wireguard \
+  gluon-ssid-changer
+
 GLUON_MULTIDOMAIN=1
 GLUON_DEPRECATED=full
 
-
 # basic support for USB stack
 USB_PACKAGES_BASIC := \
-        kmod-usb-core \
-        kmod-usb2
+  kmod-usb-core \
+  kmod-usb2
 
 # storage support for USB devices
 USB_PACKAGES_STORAGE := \
-        block-mount \
-        blkid \
-        kmod-fs-ext4 \
-        kmod-fs-vfat \
-        kmod-usb-storage \
-        kmod-usb-storage-extras \
-        kmod-nls-cp1250 \
-        kmod-nls-cp1251 \
-        kmod-nls-cp437 \
-        kmod-nls-cp775 \
-        kmod-nls-cp850 \
-        kmod-nls-cp852 \
-        kmod-nls-cp866 \
-        kmod-nls-iso8859-1 \
-        kmod-nls-iso8859-13 \
-        kmod-nls-iso8859-15 \
-        kmod-nls-iso8859-2 \
-        kmod-nls-koi8r \
-        kmod-nls-utf8 \
-        swap-utils
+  block-mount \
+  blkid \
+  kmod-fs-ext4 \
+  kmod-fs-vfat \
+  kmod-usb-storage \
+  kmod-usb-storage-extras \
+  kmod-nls-cp1250 \
+  kmod-nls-cp1251 \
+  kmod-nls-cp437 \
+  kmod-nls-cp775 \
+  kmod-nls-cp850 \
+  kmod-nls-cp852 \
+  kmod-nls-cp866 \
+  kmod-nls-iso8859-1 \
+  kmod-nls-iso8859-13 \
+  kmod-nls-iso8859-15 \
+  kmod-nls-iso8859-2 \
+  kmod-nls-koi8r \
+  kmod-nls-utf8 \
+  swap-utils
 
 # network support for USB devices
 USB_PACKAGES_NET := \
-        kmod-mii \
-        kmod-nls-base \
-        kmod-usb-net \
-        kmod-usb-net-asix \
-        kmod-usb-net-asix-ax88179 \
-        kmod-usb-net-cdc-eem \
-        kmod-usb-net-cdc-ether \
-        kmod-usb-net-cdc-mbim \
-        kmod-usb-net-cdc-ncm \
-        kmod-usb-net-cdc-subset \
-        kmod-usb-net-dm9601-ether \
-        kmod-usb-net-hso \
-        kmod-usb-net-huawei-cdc-ncm \
-        kmod-usb-net-ipheth \
-        kmod-usb-net-kalmia \
-        kmod-usb-net-kaweth \
-        kmod-usb-net-mcs7830 \
-        kmod-usb-net-pegasus \
-        kmod-usb-net-qmi-wwan \
-        kmod-usb-net-rndis \
-        kmod-usb-net-sierrawireless \
-        kmod-usb-net-smsc95xx
-# broken
-#       kmod-usb-net-rtl8150 \
-#       kmod-usb-net-rtl8152 \
+  kmod-mii \
+  kmod-nls-base \
+  kmod-usb-net \
+  kmod-usb-net-asix \
+  kmod-usb-net-asix-ax88179 \
+  kmod-usb-net-cdc-eem \
+  kmod-usb-net-cdc-ether \
+  kmod-usb-net-cdc-mbim \
+  kmod-usb-net-cdc-ncm \
+  kmod-usb-net-cdc-subset \
+  kmod-usb-net-dm9601-ether \
+  kmod-usb-net-hso \
+  kmod-usb-net-huawei-cdc-ncm \
+  kmod-usb-net-ipheth \
+  kmod-usb-net-kalmia \
+  kmod-usb-net-kaweth \
+  kmod-usb-net-mcs7830 \
+  kmod-usb-net-pegasus \
+  kmod-usb-net-qmi-wwan \
+  kmod-usb-net-rndis \
+  kmod-usb-net-sierrawireless \
+  kmod-usb-net-smsc95xx
+
 # network support for PCI devices
 PCI_PACKAGES_NET := \
-        kmod-3c59x \
-        kmod-e100 \
-        kmod-e1000 \
-        kmod-e1000e \
-        kmod-forcedeth \
-        kmod-natsemi \
-        kmod-ne2k-pci \
-        kmod-pcnet32 \
-        kmod-r8169 \
-        kmod-sis900 \
-        kmod-sky2 \
-        kmod-tg3 \
-        kmod-tulip \
-        kmod-via-rhine \
-        kmod-8139cp
-# broken
-#       kmod-ixgbe \
-#       kmod-r8139too \
+  kmod-3c59x \
+  kmod-e100 \
+  kmod-e1000 \
+  kmod-e1000e \
+  kmod-forcedeth \
+  kmod-natsemi \
+  kmod-ne2k-pci \
+  kmod-pcnet32 \
+  kmod-r8169 \
+  kmod-sis900 \
+  kmod-sky2 \
+  kmod-tg3 \
+  kmod-tulip \
+  kmod-via-rhine \
+  kmod-8139cp
+
 # additional packages
 TOOLS_PACKAGES := \
-        iperf \
-        socat \
-        tcpdump \
-        usbutils \
-        vnstat
-# broken
-#       pciutils \
-#
-#
-# $(GLUON_TARGET) specific settings:
-#
+  iperf \
+  socat \
+  tcpdump \
+  usbutils \
+  vnstat
 
 # x86-generic
 ifeq ($(GLUON_TARGET),x86-generic)
-# support the usb stack on x86 devices
-# and add a few common USB and PCI NICs
-GLUON_SITE_PACKAGES += \
-        kmod-usb-hid \
-        kmod-hid-generic \
-        $(USB_PACKAGES_BASIC) \
-        $(USB_PACKAGES_STORAGE) \
-        $(USB_PACKAGES_NET) \
-        $(PCI_PACKAGES_NET) \
-        $(TOOLS_PACKAGES)
+  GLUON_SITE_PACKAGES += \
+    kmod-usb-hid \
+    kmod-hid-generic \
+    $(USB_PACKAGES_BASIC) \
+    $(USB_PACKAGES_STORAGE) \
+    $(USB_PACKAGES_NET) \
+    $(PCI_PACKAGES_NET) \
+    $(TOOLS_PACKAGES)
 endif
 
 # x86-64
 ifeq ($(GLUON_TARGET),x86-64)
-# support the usb stack on x86-64 devices
-# and add a few common USB and PCI NICs
-GLUON_SITE_PACKAGES += \
-        kmod-usb-hid \
-        kmod-hid-generic \
-        $(USB_PACKAGES_BASIC) \
-        $(USB_PACKAGES_STORAGE) \
-        $(USB_PACKAGES_NET) \
-        $(PCI_PACKAGES_NET) \
-        $(TOOLS_PACKAGES)
+  GLUON_SITE_PACKAGES += \
+    kmod-usb-hid \
+    kmod-hid-generic \
+    $(USB_PACKAGES_BASIC) \
+    $(USB_PACKAGES_STORAGE) \
+    $(USB_PACKAGES_NET) \
+    $(PCI_PACKAGES_NET) \
+    $(TOOLS_PACKAGES)
 endif
+
 ifeq ($(GLUON_TARGET),x86-kvm_guest)
-GLUON_SITE_PACKAGES += \
-        $(TOOLS_PACKAGES)
+  GLUON_SITE_PACKAGES += \
+    $(TOOLS_PACKAGES)
 endif
 
 #ar71xx-generic
@@ -179,28 +156,8 @@ GLUON_tp-link-archer-c7-v4_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAG
 #mpc85xx-generic
 GLUON_tp-link-tl-wdr4900-v1_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 
-##      DEFAULT_GLUON_RELEASE
-#               version string to use for images
-#               gluon relies on
-#                       opkg compare-versions "$1" '>>' "$2"
-#               to decide if a version is newer or not.
-
-#DEFAULT_GLUON_RELEASE := 0.6+mstr$(shell date '+%Y%m%d')
 DEFAULT_GLUON_RELEASE := v2021.1.1-Wireguard
-
-
-##      GLUON_RELEASE
-#               call make with custom GLUON_RELEASE flag, to use your own release version scheme.
-#               e.g.:
-#                       $ make images GLUON_RELEASE=23.42+5
-#               would generate images named like this:
-#                       gluon-ff%site_code%-23.42+5-%router_model%.bin
-
-# Allow overriding the release number from the command line
-
 GLUON_RELEASE ?= v2021.1.2-Wireguard
-
-
 
 # Default priority for updates.
 GLUON_PRIORITY ?= 0


### PR DESCRIPTION
Das offline-ssid-branch Paket wird derzeit in meinem eignen Repo gehostet, da ich diesen angepasst habe (https://github.com/jzielke84/gluon-ssid-changer). Um auf Wunsch den code später eventuell nach https://github.com/ff-kbu zu überführen benötige ich jedoch die Rechte dazu.

Edit: Simon hat mir die Rechte dazu nun gegeben. Das SSID-Modul liegt ab sofort hier: https://github.com/ff-kbu/gluon-ssid-changer